### PR TITLE
Store the caller-id selection into Agent attributes.

### DIFF
--- a/plugin-outbound-callerid/src/OutboundCalleridPlugin.js
+++ b/plugin-outbound-callerid/src/OutboundCalleridPlugin.js
@@ -50,7 +50,12 @@ export default class OutboundCalleridPlugin extends FlexPlugin {
 
     manager.store.dispatch(NumberSelectActions.setCallerIds(callerIds));
     //Set initial caller id
-    manager.store.dispatch(NumberSelectActions.updateNumber(callerIds[0].phoneNumber))
+    if(manager.workerClient.attributes.lastSelectedCallerId) {
+      console.log(PLUGIN_NAME, 'Found a previous caller id: ', manager.workerClient.attributes.lastSelectedCallerId);
+      manager.store.dispatch(NumberSelectActions.updateNumber(manager.workerClient.attributes.lastSelectedCallerId));
+    } else {
+      manager.store.dispatch(NumberSelectActions.updateNumber(callerIds[0].phoneNumber))
+    }
 
 
     flex.OutboundDialerPanel.Content.add(

--- a/plugin-outbound-callerid/src/OutboundCalleridPlugin.js
+++ b/plugin-outbound-callerid/src/OutboundCalleridPlugin.js
@@ -50,7 +50,7 @@ export default class OutboundCalleridPlugin extends FlexPlugin {
 
     manager.store.dispatch(NumberSelectActions.setCallerIds(callerIds));
     //Set initial caller id
-    if(manager.workerClient.attributes.lastSelectedCallerId) {
+    if(manager.workerClient.attributes.lastSelectedCallerId && callerIds.find(o => o.phoneNumber === manager.workerClient.attributes.lastSelectedCallerId)) {
       console.log(PLUGIN_NAME, 'Found a previous caller id: ', manager.workerClient.attributes.lastSelectedCallerId);
       manager.store.dispatch(NumberSelectActions.updateNumber(manager.workerClient.attributes.lastSelectedCallerId));
     } else {

--- a/plugin-outbound-callerid/src/states/NumberSelectState.js
+++ b/plugin-outbound-callerid/src/states/NumberSelectState.js
@@ -1,3 +1,5 @@
+import {Manager} from "@twilio/flex-ui";
+
 const UPDATE_DIALER_NUMBER = "UPDATE_NUMBER";
 const CLEAR_DIALER_NUMBER = "CLEAR_NUMBER";
 const SET_CALLER_IDS = "SET_CALLER_IDS";
@@ -27,12 +29,16 @@ export class Actions {
 export function reduce(state = initialState, action) {
   switch (action.type) {
     case UPDATE_DIALER_NUMBER: {
+      const worker = Manager.getInstance().workerClient;
+      worker.setAttributes({...worker.attributes, lastSelectedCallerId:action.phoneNumber});
       return {
         ...state,
         phoneNumber: action.phoneNumber
       };
     }
     case CLEAR_DIALER_NUMBER: {
+      const worker = Manager.getInstance().workerClient;
+      worker.setAttributes({...worker.attributes, lastSelectedCallerId:null});
       return {
         ...state,
         phoneNumber: undefined


### PR DESCRIPTION
Hello ! 

Small PR to add a requested feature : record the agent selection so they don't have to set the caller id every time they log in. 

Hope this helps, let me know if I should do anything. 

Jonas (Twilio SE in Paris)