### PR TITLE
stop tracking .twiliodeployinfo

### DIFF
--- a/serverless/.twiliodeployinfo
+++ b/serverless/.twiliodeployinfo
@@ -1,6 +1,0 @@
-{
-	"AC7e3399e44ce5e6a360b275e1f9c72d61": {
-		"serviceSid": "ZS17d43f0455afcf9f7a1120e2e9eb4f27",
-		"latestBuild": "ZB5ee41dedb186a35b0fd581e8ebaf28bc"
-	}
-}


### PR DESCRIPTION
removing  the deployment file (which contains a SID already)